### PR TITLE
fixing onOpen

### DIFF
--- a/client.js
+++ b/client.js
@@ -19,6 +19,11 @@ module.exports = class DiscoverySwarmClient extends EventEmitter {
     this.queued = 0
     this.connected = 0
 
+    var handleOpen = this._handleOpen.bind(this)
+
+    this._protocol.connect()
+    this._protocol.on('swarm:open', handleOpen)
+
     if (options.stream) { this._replicate = options.stream }
   }
 


### PR DESCRIPTION
_handleOpen wasn´t called on open

With this the client is able to connect to my server and send messages to a peer.
For some reason it is not able to receive the messages from the peer.