### PR TITLE
Stability improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Alows clients to use [discovery-channel](https://github.com/maxogden/discovery-c
 
 Clients connect to the server, search for "discovery keys", and the proxy automatically discovers and connects to peers and then proxies those connections to the client.
 
-If two clients are discovering the same key, the proxy can connect them to each other
+If two clients are discovering the same key, the proxy can connect them to each other if you set the `connectExistingClients` on the server.
 
 Requires:
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Clients connect to the server, search for "discovery keys", and the proxy automa
 
 If two clients are discovering the same key, the proxy can connect them to each other if you set the `connectExistingClients` on the server.
 
+By default it supports connections for the [hypercore-protocol](https://github.com/mafintosh/hypercore-protocol) used in [Dat](https://datproject.org/). If you'd like to support a different protocol, provide a `stream` argument that conforms to what's expected in [discovery-swarm](https://www.npmjs.com/package/discovery-swarm#var-sw--swarmopts).
+
 Requires:
 
 - ES6 classes

--- a/demo/index.js
+++ b/demo/index.js
@@ -5,27 +5,7 @@ var RAM = require('random-access-memory')
 var DSSServer = require('../server')
 var DSSClient = require('../client')
 
-// Taken from dat swarm defaults
-var DAT_DOMAIN = 'dat.local'
-var DEFAULT_DISCOVERY = [
-  'discovery1.datprotocol.com',
-  'discovery2.datprotocol.com'
-]
-var DEFAULT_BOOTSTRAP = [
-  'bootstrap1.datprotocol.com:6881',
-  'bootstrap2.datprotocol.com:6881',
-  'bootstrap3.datprotocol.com:6881',
-  'bootstrap4.datprotocol.com:6881'
-]
-
-var DEFAULT_OPTS = {
-  dns: { server: DEFAULT_DISCOVERY, domain: DAT_DOMAIN },
-  dht: { bootstrap: DEFAULT_BOOTSTRAP },
-  // MAKE SURE YOU ADD THIS!
-  hash: false
-}
-
-var server = new DSSServer(DEFAULT_OPTS)
+var server = new DSSServer({})
 
 var tcpServer = net.createServer((socket) => {
   console.log('Server got connection')

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "websocket-stream": "^5.1.2"
   },
   "dependencies": {
-    "discovery-channel": "^5.5.1",
+    "hyperdiscovery": "^9.0.0",
     "length-prefixed-stream": "^1.6.0",
     "protocol-buffers-encodings": "^1.1.0",
     "readable-stream": "^2.3.6",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "websocket-stream": "^5.1.2"
   },
   "dependencies": {
+    "debug": "^4.1.1",
     "hyperdiscovery": "^9.0.0",
     "length-prefixed-stream": "^1.6.0",
     "protocol-buffers-encodings": "^1.1.0",

--- a/server.js
+++ b/server.js
@@ -26,12 +26,20 @@ module.exports = class DiscoverySwarmStreamServer extends EventEmitter {
 
       debug('got connection', info)
 
-      stream.on('feed', (key) => {
+      if(info.channel) {
+        process.nextTick(() => {
+          emitKeyAndClose(info.channel)
+        })
+      }
+
+      stream.on('feed', emitKeyAndClose)
+
+      function emitKeyAndClose(key) {
         debug('got key from connection', key, info)
         this.emit('key:' + key.toString('hex'), key, info)
         stream.end()
         this._discovery._swarm._peersSeen[info.id] = null
-      })
+      }
 
       return stream
     }

--- a/server.js
+++ b/server.js
@@ -16,6 +16,9 @@ module.exports = class DiscoverySwarmStreamServer extends EventEmitter {
     this.connectExistingClients = !!options.connectExistingClients
     this._discovery = createDiscovery(options)
 
+    // For making sure other peers don't remember us
+    this._discovery.id = null
+
     // I am not proud of this code
     const createStream = options.stream || this._discovery._createReplicationStream.bind(this._discovery)
     this._discovery._swarm._stream = (info) => {

--- a/server.js
+++ b/server.js
@@ -27,10 +27,15 @@ module.exports = class DiscoverySwarmStreamServer extends EventEmitter {
         debug('got key from connection', key, info)
         this.emit('key:' + key.toString('hex'), key, info)
         stream.end()
+        this._discovery._swarm._peersSeen[info.id] = null
       })
 
       return stream
     }
+
+    this._discovery.on('connection', () => {
+      connection.close()
+    })
 
     this._discovery.on('close', () => this.emit('close'))
 

--- a/server.js
+++ b/server.js
@@ -26,6 +26,7 @@ module.exports = class DiscoverySwarmStreamServer extends EventEmitter {
       stream.on('feed', (key) => {
         debug('got key from connection', key, info)
         this.emit('key:' + key.toString('hex'), key, info)
+        stream.end()
       })
 
       return stream
@@ -122,6 +123,7 @@ class Client extends DiscoverySwarmStream {
     this._swarm = swarm
 
     this.on('swarm:join', (key) => {
+      debug('joining discovery key', this.id.toString('hex'), key)
       var stringKey = key.toString('hex')
       this._swarm.on('key:' + stringKey, this.connectTCP)
       this._subscriptions.push(stringKey)

--- a/server.js
+++ b/server.js
@@ -26,6 +26,13 @@ module.exports = class DiscoverySwarmStreamServer extends EventEmitter {
 
       debug('got connection', info)
 
+      const emitKeyAndClose = (key) => {
+        debug('got key from connection', key, info)
+        this.emit('key:' + key.toString('hex'), key, info)
+        stream.end()
+        this._discovery._swarm._peersSeen[info.id] = null
+      }
+
       if(info.channel) {
         process.nextTick(() => {
           emitKeyAndClose(info.channel)
@@ -33,13 +40,6 @@ module.exports = class DiscoverySwarmStreamServer extends EventEmitter {
       }
 
       stream.on('feed', emitKeyAndClose)
-
-      function emitKeyAndClose(key) {
-        debug('got key from connection', key, info)
-        this.emit('key:' + key.toString('hex'), key, info)
-        stream.end()
-        this._discovery._swarm._peersSeen[info.id] = null
-      }
 
       return stream
     }

--- a/server.js
+++ b/server.js
@@ -12,6 +12,8 @@ module.exports = class DiscoverySwarmStreamServer extends EventEmitter {
     if (!options) {
       options = {}
     }
+
+    this.connectExistingClients = !!options.connectExistingClients
     this._discovery = discoveryChannel(options)
     this._discovery.on('peer', (key, peer) => {
       this.emit('key:' + key.toString('hex'), key, peer)
@@ -109,6 +111,10 @@ class Client extends DiscoverySwarmStream {
       this._swarm.on('key:' + stringKey, this.connectTCP)
       this._subscriptions.push(stringKey)
       this._swarm._joinClient(key, this)
+
+      // Don't connect clients together unless you need it
+      // This is to encourage connections through WebRTC
+      if(!this._swarm.connectExistingClients) return
 
       var existing = this._swarm.subscribedClients(key)
 


### PR DESCRIPTION
Enables the server to listen for incoming connections in addition to making outgoing connections.

This enables dat-js to share archives created in a browser with the rest of the network and should improve stability.

Also disables the local peer connections by default since this is mostly used in conjunction with WebRTC.

Closes #7 